### PR TITLE
add clone and debug derive for OperandArrayVec

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -266,6 +266,7 @@ pub type AllOperands = OperandArrayVec<MAX_OPERAND_COUNT>;
 
 /// Decode and store operands in a static array buffer.
 #[cfg(feature = "full-decoder")]
+#[derive(Debug, Clone)]
 pub struct OperandArrayVec<const MAX_OPERANDS: usize> {
     // TODO: use maybeuninit here
     operands: [ffi::DecodedOperand; MAX_OPERANDS],


### PR DESCRIPTION
Hi, I found that Instruction<AllOperands> and Instruction<VisibleOperands> do not have the traits for Clone and Debug.
This is because the OperandArrayVec does not implement the traits.
Could you consider adding them?